### PR TITLE
Fix confusing variable name

### DIFF
--- a/pcpostprocess/scripts/run_herg_qc.py
+++ b/pcpostprocess/scripts/run_herg_qc.py
@@ -1136,9 +1136,9 @@ def get_time_constant_of_first_decay(trace, times, protocol_desc, args, output_p
         if not os.path.exists(os.path.dirname(output_path)):
             os.makedirs(os.path.dirname(output_path))
 
-    first_120mV_step_index = [i for i, line in enumerate(protocol_desc) if line[2] == 40][0]
+    first_120mV_step_index = [i for i, line in enumerate(protocol_desc) if line[2] == 40][0] + 1
 
-    tstart, tend, vstart, vend = protocol_desc[first_120mV_step_index + 1, :]
+    tstart, tend, vstart, vend = protocol_desc[first_120mV_step_index, :]
     assert (vstart == vend)
     assert (vstart == -120.0)
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix the calculation of the index of the first -120mV step. 
<!--- Why is this change required? What problem does it solve? -->
The variable first_120mV_step_index was originally assigned the index of the preceding +40mV step, causing confusion.
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested)-->

## Documentation checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation in the code where necessary.
- [ ] I have checked spelling in all (new) comments and documentation.
- [ ] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).
