### PR TITLE
Removed wrong/unnecessary stuff from readme, simplified pytest workflow, added python 13

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,47 +6,49 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
     steps:
-    - name: Checkout repository and submodules
+    - name: Checkout repository
       uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - name: Checkout github repo (+ download lfs dependencies)
-      uses: actions/checkout@v4
-      with:
-        lfs: true
-    - name: Checkout LFS objects
-      run: git lfs checkout
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         eval `ssh-agent -s`
         ssh-add - <<< '${{ secrets.syncropatch_export_key }}'
         python -m pip install --upgrade pip
         python -m pip install -e .[test]
+
+    - name: Lint with flake8
+      run: |
+        python -m flake8 pcpostprocess/*.py tests/*.py pcpostprocess/scripts/*.py
+
+    - name: Import sorting with isort
+      run: |
+        python -m isort --verbose --check-only --diff pcpostprocess tests setup.py
+
     - name: Extract test data
       run: |
         wget https://cardiac.nottingham.ac.uk/syncropatch_export/test_data.tar.xz -P tests/
         tar xvf tests/test_data.tar.xz -C tests/
+
     - name: Test with pytest
       run: |
         python -m pip install -e .
         python -m pytest --cov --cov-config=.coveragerc
+
     - name: Run export with test data
       timeout-minutes: 15
       run: |
         sudo apt-get install dvipng texlive-latex-extra texlive-fonts-recommended cm-super -y
         pcpostprocess run_herg_qc tests/test_data/13112023_MW2_FF -w A01 A02 A03
-    - uses: codecov/codecov-action@v1
+
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-    - name: Lint with flake8
-      run: |
-        python -m flake8 pcpostprocess/*.py tests/*.py pcpostprocess/scripts/*.py
-    - name: Import sorting with isort
-      run: |
-        python -m isort --verbose --check-only --diff pcpostprocess tests setup.py
+      if: success() && matrix.python-version == 3.13
+

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,8 +18,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        eval `ssh-agent -s`
-        ssh-add - <<< '${{ secrets.syncropatch_export_key }}'
         python -m pip install --upgrade pip
         python -m pip install -e .[test]
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,10 +41,14 @@ jobs:
         python -m pip install -e .
         python -m pytest --cov --cov-config=.coveragerc
 
-    - name: Run export with test data
+    - name: Install TeX dependencies
       timeout-minutes: 15
       run: |
         sudo apt-get install dvipng texlive-latex-extra texlive-fonts-recommended cm-super -y
+
+    - name: Test running QC
+      timeout-minutes: 15
+      run: |
         pcpostprocess run_herg_qc tests/test_data/13112023_MW2_FF -w A01 A02 A03
 
     - uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /tests/test_data
 /test_output
-*.pyc
-*.DS_Store
 *__pycache__*
 *.egg-info
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,97 +1,47 @@
-
-<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
-<a name="readme-top"></a>
-
-<!-- PROJECT SHIELDS -->
 [![Unit tests](https://github.com/CardiacModelling/pcpostprocess/actions/workflows/pytest.yml/badge.svg)](https://github.com//CardiacModelling/pcpostprocess/actions/workflows/pytest.yml)
 [![codecov](https://codecov.io/gh/CardiacModelling/pcpostprocess/graph/badge.svg?token=HOL0FrpGqs)](https://codecov.io/gh/CardiacModelling/pcpostprocess)
 
+This repository contains a python package and scripts for handling time-series data from patch-clamp experiments.
+The package has been tested with data from a SyncroPatch 384, but may be adapted to work with data in other formats.
+It can also be used to perform quality control (QC) as described in [Lei et al. (2019)](https://doi.org/10.1016%2Fj.bpj.2019.07.029).
 
-<!-- PROJECT LOGO -->
-<!-- <br /> -->
-<!-- <div align="center"> -->
-<!--     <img src="images/logo.png" alt="Logo" width="80" height="80"> -->
-<!--   </a> -->
+This package is tested on Ubuntu with Python 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13.
 
-
-<!-- TABLE OF CONTENTS -->
-<details>
-  <summary>Table of Contents</summary>
-  <ol>
-    <li>
-      <a href="#about-the-project">About The Project</a>
-      <ul>
-        <li><a href="#built-with">Built With</a></li>
-      </ul>
-    </li>
-    <li>
-      <a href="#getting-started">Getting Started</a>
-      <ul>
-        <li><a href="#prerequisites">Prerequisites</a></li>
-        <li><a href="#installation">Installation</a></li>
-      </ul>
-    </li>
-    <li><a href="#usage">Usage</a></li>
-    <li><a href="#roadmap">Roadmap</a></li>
-    <li><a href="#contributing">Contributing</a></li>
-    <li><a href="#license">License</a></li>
-    <li><a href="#contact">Contact</a></li>
-    <li><a href="#acknowledgments">Acknowledgments</a></li>
-  </ol>
-</details>
-
-
-<!-- ABOUT THE PROJECT -->
-## About The Project
-This project contains a python package and scripts for handling time-series data from patch-clamp experiments. The package has been tested with data from a SyncroPatch 384, but may be adapted to work with data in other formats. The package can also be used to perform quality control (QC) as described in [Lei et al. (2019)](https://doi.org/10.1016%2Fj.bpj.2019.07.029).
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-<!-- GETTING STARTED -->
 ## Getting Started
 
-This is an example of how you may give instructions on setting up your project locally.
-To get a local copy up and running follow these simple example steps.
+First clone the repository
 
-### Prerequisites
-
-This package has been tested on Ubuntu with Python 3.8, 3.9, 3.10, 3.11 and 3.12.
-
-### Installation
-
-First clone this repository
-
-```
-git clone git@github.com:CardiacModelling/pcpostprocess && cd pcpostprocess
+```sh
+git clone git@github.com:CardiacModelling/pcpostprocess
+cd pcpostprocess
 ```
 
-With one of these versions install, create and activate a virtual environment.
+Create and activate a virtual environment.
 
-  ```sh
-  python3 -m venv .venv && source .venv/bin/activate
-  ```
+```sh
+python3 -m venv .venv && source .venv/bin/activate
+```
 
 Then install the package with `pip`.
 
-```
+```sh
 python3 -m pip install --upgrade pip && python3 -m pip install -e .'[test]'
 ```
 
-To run the tests you must first download some test data. Test data is available at [cardiac.nottingham.ac.uk/syncropatch\_export](https://cardiac.nottingham.ac.uk/syncropatch_export)
+To run the tests you must first download some test data.
+Test data is available at [cardiac.nottingham.ac.uk/syncropatch\_export](https://cardiac.nottingham.ac.uk/syncropatch_export)
 
-```
+```sh
 wget https://cardiac.nottingham.ac.uk/syncropatch_export/test_data.tar.xz -P tests/
 tar xvf tests/test_data.tar.xz -C tests/
+rm tests/test_data.tar.xz
 ```
 
 Then you can run the tests.
-```
+```sh
 python3 -m unittest
 ```
 
-
-<!-- USAGE -->
 ## Usage
 
 ### Running QC and post-processing
@@ -100,7 +50,7 @@ Quality control (QC) may be run using the criteria outlined in [Rapid Characteri
 
 Prior to performing QC and exporting, an `export_config.py` file should be added to the root of the data directory. This file (see `example_config.py`) contains a Python `dict` (`Q2S_DC`) specifying the filenames of the protocols used for QC, and names they should be outputted with, as well as a Python `dict` (`D2S`) listing the other protocols and names to be used for their output. Additionally, the `saveID` field specifies the name of the expeirment which appears in the output file names.
 
-```
+```sh
 $ pcpostprocess run_herg_qc --help
 
 usage: pcpostprocess run_herg_qc [-h] [-c NO_CPUS]
@@ -130,12 +80,11 @@ options:
   --Erev EREV           The reversal potential during the experiment
 ```
 
-
 ### Exporting Summary
 
 The `summarise_herg_export` command produces additionally output after `run_herg_qc` has been run.
 
-```
+```sh
 $ pcpostprocess summarise_herg_export --help
 
 usage: pcpostprocess summarise_herg_export [-h] [--cpus CPUS]
@@ -162,70 +111,3 @@ options:
   --log_level LOG_LEVEL
 ```
 
-
-<!-- CONTRIBUTING -->
-## Contributing
-
-Any contributions you make are **greatly appreciated**.
-
-If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement".
-
-1. Fork the Project
-2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the Branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<!-- LICENSE -->
-## License
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-
-<!-- CONTACT -->
-## Contact
-
-Joseph Shuttleworth joseph.shuttleworth@nottingham.ac.uk
-
-Project Link: [https://github.com/CardiacModelling/pcpostprocess](https://github.com/CardiacModelling/pcpostprocess)
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-
-<!-- MARKDOWN LINKS & IMAGES -->
-<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
-[contributors-shield]: https://img.shields.io/github/contributors/CardiacModelling/pcpostprocess.svg?style=for-the-badge
-[contributors-url]: https://github.com/CardiacModelling/pcpostprocess/graphs/contributors
-[forks-shield]: https://img.shields.io/github/forks/CardiacModelling/pcpostprocess.svg?style=for-the-badge
-[forks-url]: https://github.com/CardiacModelling/pcpostprocess/network/members
-[stars-shield]: https://img.shields.io/github/stars/CardiacModelling/pcpostprocess.svg?style=for-the-badge
-[stars-url]: https://github.com/CardiacModelling/pcpostprocess/stargazers
-[issues-shield]: https://img.shields.io/github/issues/CardiacModelling/pcpostprocess.svg?style=for-the-badge
-[issues-url]: https://github.com/CardiacModelling/pcpostprocess/issues
-[license-shield]: https://img.shields.io/github/license/Cardiac/Modelling/pcpostprocess.svg?style=for-the-badge
-[license-url]: https://github.com/CardiacModelling/pcpostprocess/blob/master/LICENSE.txt
-[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
-[linkedin-url]: https://linkedin.com/in/linkedin_username
-[product-screenshot]: images/screenshot.png
-[Next.js]: https://img.shields.io/badge/next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white
-[Next-url]: https://nextjs.org/
-[React.js]: https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB
-[React-url]: https://reactjs.org/
-[Vue.js]: https://img.shields.io/badge/Vue.js-35495E?style=for-the-badge&logo=vuedotjs&logoColor=4FC08D
-[Vue-url]: https://vuejs.org/
-[Angular.io]: https://img.shields.io/badge/Angular-DD0031?style=for-the-badge&logo=angular&logoColor=white
-[Angular-url]: https://angular.io/
-[Svelte.dev]: https://img.shields.io/badge/Svelte-4A4A55?style=for-the-badge&logo=svelte&logoColor=FF3E00
-[Svelte-url]: https://svelte.dev/
-[Laravel.com]: https://img.shields.io/badge/Laravel-FF2D20?style=for-the-badge&logo=laravel&logoColor=white
-[Laravel-url]: https://laravel.com
-[Bootstrap.com]: https://img.shields.io/badge/Bootstrap-563D7C?style=for-the-badge&logo=bootstrap&logoColor=white
-[Bootstrap-url]: https://getbootstrap.com
-[JQuery.com]: https://img.shields.io/badge/jQuery-0769AD?style=for-the-badge&logo=jquery&logoColor=white
-[JQuery-url]: https://jquery.com 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
             'isort',
             'mock>=3.0.5',         # For mocking command line args etc.
             'codecov>=2.1.3',
-            'syncropatch_export @ git+ssh://git@github.com/CardiacModelling/syncropatch_export.git'
+            'syncropatch_export @ git+https://github.com/CardiacModelling/syncropatch_export.git'
         ],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
             'isort',
             'mock>=3.0.5',         # For mocking command line args etc.
             'codecov>=2.1.3',
-            'syncropatch_export @ git+ssh://git@github.com/CardiacModelling/syncropatch_export@main'
+            'syncropatch_export @ git+ssh://git@github.com/CardiacModelling/syncropatch_export.git'
         ],
     },
     entry_points={


### PR DESCRIPTION
- Removed unused template stuff from README, making it readable again, removing need for TOC etc
- Added testing on 3.13
- Removed lfs and other unused stuff from pytest workflow
- Split off tex dependency install from QC test, so that (1) we can see the output without wading through apt logs (2) we can see how long each takes