### PR TITLE
Unit test updates

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -54,5 +54,5 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-      if: success() && matrix.python-version == 3.13
+      if: success() && matrix.python-version == 3.14
 


### PR DESCRIPTION
- Don't unit test draft PRs. 
- Add 3.14
- Remove 3.8 (eol) and 3.9 (eol this month) https://devguide.python.org/versions/