### PR TITLE
Make default plotsize bigger

### DIFF
--- a/pcpostprocess/scripts/run_herg_qc.py
+++ b/pcpostprocess/scripts/run_herg_qc.py
@@ -51,7 +51,7 @@ def main():
     parser.add_argument('--reversal_spread_threshold', type=float, default=10)
     parser.add_argument('--export_failed', action='store_true')
     parser.add_argument('--selection_file')
-    parser.add_argument('--figsize', nargs=2, type=int, default=[5, 8])
+    parser.add_argument('--figsize', nargs=2, type=int, default=[16, 18])
     parser.add_argument('--debug', action='store_true')
     parser.add_argument('--log_level', default='INFO')
     parser.add_argument('--Erev', default=-90.71, type=float)


### PR DESCRIPTION
## Description
Change made to the default parser argument 'figsize' to enable larger plots (e.g. subtraction plots)

## Types of changes
- [ ] Aesthetic change to plotting (non-breaking change which adds functionality)