### PR TITLE
Fix bug in QC.R_leftover

### DIFF
--- a/pcpostprocess/scripts/run_herg_qc.py
+++ b/pcpostprocess/scripts/run_herg_qc.py
@@ -314,6 +314,15 @@ def main():
         passed_QC_Erev_spread = E_rev_spread <= args.reversal_spread_threshold
         logging.info(f"passed_QC_Erev_spread {passed_QC_Erev_spread}")
 
+        # R_leftover only considered for protocols used for QC (i.e. staircase protocols)
+        passed_QC_R_leftover = np.all(sub_df[sub_df.protocol.isin(args.D2SQC.values())]
+                                      ["QC.R_leftover"].values
+                                      )
+
+        logging.info(f"passed_QC_R_leftover {passed_QC_R_leftover}")
+
+        passed_QC_Erev_spread = E_rev_spread <= args.reversal_spread_threshold
+
         qc_erev_spread[well] = passed_QC_Erev_spread
         erev_spreads[well] = E_rev_spread
 


### PR DESCRIPTION
Fixes bug introduced by recent merge. The boolean column "QC.R_leftover" is checked (all must be true for a well to pass) rather than the float column "R_leftover" which merely reports values, and will always be true for any positive value. 