### PR TITLE
"Fix" summarise-herg-qc

### DIFF
--- a/pcpostprocess/scripts/summarise_herg_export.py
+++ b/pcpostprocess/scripts/summarise_herg_export.py
@@ -895,9 +895,10 @@ def create_attrition_table(qc_df, subtraction_df):
                             'qc6.subtracted', 'qc6.1.subtracted',
                             'qc6.2.subtracted']
 
-    subtraction_df_sc = subtraction_df[subtraction_df.protocol.isin(['staircaseramp1',
-                                                                     'staircaseramp1_2'])]
-    R_leftover_qc = subtraction_df_sc.groupby('well')['R_leftover'].max() < 0.4
+    # subtraction_df_sc = subtraction_df[
+    #    subtraction_df.protocol.isin(['staircaseramp1', 'staircaseramp1_2'])]
+
+    # R_leftover_qc = subtraction_df_sc.groupby('well')['R_leftover'].max() < 0.4
 
     # This line doesn't work: "Length of values does not match length of index"
     # qc_df['QC.R_leftover'] = [R_leftover_qc.loc[well] for well in subtraction_df.well.unique()]
@@ -907,7 +908,7 @@ def create_attrition_table(qc_df, subtraction_df):
     stage_4_criteria = stage_3_criteria + ['qc3.bookend']
     stage_5_criteria = stage_4_criteria + ['QC.Erev.all_protocols', 'QC.Erev.spread']
 
-    #stage_6_criteria = stage_5_criteria + ['QC.R_leftover']
+    # stage_6_criteria = stage_5_criteria + ['QC.R_leftover']
 
     agg_dict = {crit: 'min' for crit in stage_5_criteria}
 


### PR DESCRIPTION
- Updated default experiment name to match test data
- Removed `qc_vals_df` which referred to a non-existent `args.save_dir` variable and a file not currently produced by run_herg_qc, and seemed to be unused anyway
- dropped "stage 6 criteria" based on `QC.R_leftover` which was causing the exception below

```
Traceback (most recent call last):
  File "/home/michael/dev/pipeline/venv/bin/pcpostprocess", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/michael/dev/pipeline/pcpostprocess/pcpostprocess/scripts/__main__.py", line 24, in main
    summarise_herg_export.main()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/michael/dev/pipeline/pcpostprocess/pcpostprocess/scripts/summarise_herg_export.py", line 148, in main
    attrition_df = create_attrition_table(qc_df, leak_parameters_df)
  File "/home/michael/dev/pipeline/pcpostprocess/pcpostprocess/scripts/summarise_herg_export.py", line 905, in create_attrition_table
    qc_df['QC.R_leftover'] = [R_leftover_qc.loc[well] for well in subtraction_df.well.unique()]
    ~~~~~^^^^^^^^^^^^^^^^^
  File "/home/michael/dev/pipeline/venv/lib64/python3.13/site-packages/pandas/core/frame.py", line 4322, in __setitem__
    self._set_item(key, value)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/michael/dev/pipeline/venv/lib64/python3.13/site-packages/pandas/core/frame.py", line 4535, in _set_item
    value, refs = self._sanitize_column(value)
                  ~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/home/michael/dev/pipeline/venv/lib64/python3.13/site-packages/pandas/core/frame.py", line 5288, in _sanitize_column
    com.require_length_match(value, self.index)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/michael/dev/pipeline/venv/lib64/python3.13/site-packages/pandas/core/common.py", line 573, in require_length_match
    raise ValueError(
    ...<4 lines>...
    )
ValueError: Length of values (26) does not match length of index (768)
```