### PR TITLE
Change return value of "detect_ramp_bounds"

### DIFF
--- a/pcpostprocess/detect_ramp_bounds.py
+++ b/pcpostprocess/detect_ramp_bounds.py
@@ -9,7 +9,7 @@ def detect_ramp_bounds(times, voltage_sections, ramp_index=0):
     @param voltage_sections 2d np.array where each row describes a segment of the protocol: (tstart, tend, vstart, end)
     @param ramp_index: the index of the ramp to select. Defaults to 0 - the first ramp
 
-    @returns istart, iend: the start and end timepoint indices for the specified ramp
+    @returns istart, iend: the first timepoint of the ramp segment, and the first time point of the following ramp segment
     """
 
     ramps = [(tstart, tend, vstart, vend) for tstart, tend, vstart, vend

--- a/pcpostprocess/detect_ramp_bounds.py
+++ b/pcpostprocess/detect_ramp_bounds.py
@@ -22,6 +22,6 @@ def detect_ramp_bounds(times, voltage_sections, ramp_index=0):
 
     tstart, tend = ramp[:2]
 
-    ramp_bounds = [np.argmax(times > tstart), np.argmax(times > tend)]
+    ramp_bounds = [np.argmax(times >= tstart), np.argmax(times >= tend)]
     return ramp_bounds
 


### PR DESCRIPTION
The function `detect_ramp_bounds` is used for reversal potential inference and leak-current correction. The values returned are unintuitive and cause problems with reversal potential plots #130. 

Instead, return first time-point in segment and first time-point in the next segment. 

Update docstring to reflect changes